### PR TITLE
Add ctrl-r keymap to redo.

### DIFF
--- a/vim.keymap
+++ b/vim.keymap
@@ -1,1 +1,2 @@
-{:+ {:find-bar.vim {"enter" [:find.hide]}}}
+{:+ {:find-bar.vim {"enter" [:find.hide]}
+     :editor {"ctrl-r" [:editor.redo]}}}


### PR DESCRIPTION
It's a default keymap in vim.
Solves https://github.com/LightTable/LightTable/issues/800
