### PR TITLE
Fix ctrl-d in vim normal mode

### DIFF
--- a/vim.keymap
+++ b/vim.keymap
@@ -1,1 +1,3 @@
-{:+ {:find-bar.vim {"enter" [:find.hide]}}}
+{:+ {:find-bar.vim {"enter" [:find.hide]}
+     :editor.keys.vim.normal {"ctrl-d"  [:passthrough]
+                              "pmeta-d" [:editor.doc.toggle]}}}


### PR DESCRIPTION
Changed keymap in vim normal mode to passthrough ctrl-d and remap :editor.doc.toggle to pmeta-d.  Fixes #18 
