### PR TITLE
Call notifos/msg* when recording macros.

### DIFF
--- a/vim.js
+++ b/vim.js
@@ -580,9 +580,9 @@
             vimGlobalState.registerController.getRegister(registerName);
         if (register) {
           register.clear();
+          lt.objs.notifos.msg_STAR_('(recording)['+registerName+']');
           this.latestRegister = registerName;
-          this.onRecordingDone = cm.openDialog(
-              '(recording)['+registerName+']', null, {bottom:true});
+          this.onRecordingDone = function(){lt.objs.notifos.msg_STAR_('');};
           this.isRecording = true;
         }
       }


### PR DESCRIPTION
The call to openDialog did not work, which would cause macro recording to fail.

notifos/msg\* calls accurately simulate in LT the behavior that is expected in vim.
