### PR TITLE
Add a two character shortcut ('jk' by default) to exit insert-mode

### DIFF
--- a/vim.js
+++ b/vim.js
@@ -4064,8 +4064,11 @@
       } else {
         return function(cm) {
           vimGlobalState.awaitingEscapeSecondCharacter = false;
-          cm.replaceRange('', {ch: cm.getCursor().ch - 1, line: cm.getCursor().line},
-                          cm.getCursor(), "+input");
+          //cm.replaceRange('', {ch: cm.getCursor().ch - 1, line: cm.getCursor().line},
+          //                cm.getCursor(), "+input");
+          var vim = maybeInitVimState(cm);
+          var command = { keys: ['u'], type: 'action', action: 'undo' };
+          commandDispatcher.processAction(cm, vim, command);
           exitInsertMode(cm);
         };
       }


### PR DESCRIPTION
Merges the relevant parts of https://github.com/marijnh/CodeMirror/pull/2719 to add the key combo 'jk' to exit insert mode (partially addressing https://github.com/LightTable/Vim/issues/12). You can set the keys you want to use by editing lines 645-6 of vim.js, e.g. to use 'ii':

```
firstEscCharacter: 'i',
secondEscCharacter: 'i',
```

If using a repeated key (like 'ii' above), you may also want to change the escSequenceTimeout to say 200ms on line 649 - I personally found it difficult to reliably press the same key twice that fast :)

```
escSequenceTimeout: 200,
```

N.b. macro recording using this shortcut won't work, so just use ESC to exit insert-mode when recording macros.

Additionally to disable this functionality set line 641 to false

```
enableEscKeymap: false,
```

Here is the now closed issue on CodeMirror for more info about the original patch. https://github.com/marijnh/CodeMirror/issues/1990

SO link with slightly more info: http://stackoverflow.com/a/24997067/104264

P.S. Chris - keep up the good work - much love and respect :)
